### PR TITLE
Update ubuntu64-core-01.sh

### DIFF
--- a/common/ubuntu64-core-01.sh
+++ b/common/ubuntu64-core-01.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-curl -sSL http://cdimage.ubuntu.com/ubuntu-core/releases/15.10/release/ubuntu-core-15.10-core-arm64.tar.gz | sudo tar --numeric-owner -xpzf - -C rootfs/
+curl -sSL http://cdimage.ubuntu.com/ubuntu-core/releases/16.04/release/ubuntu-core-16.04-core-arm64.tar.gz | sudo tar --numeric-owner -xpzf - -C rootfs/
 
 sudo mount -o bind /dev ./rootfs/dev
 sudo mount -o bind /dev/pts ./rootfs/dev/pts


### PR DESCRIPTION
Odroid-C2 and PINE64 already has Ubuntu 16.04 Xenial support, but still downloading old Ubuntu Core 15.10