### PR TITLE
setting 7.4.1708 version

### DIFF
--- a/common/centos64-01.sh
+++ b/common/centos64-01.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -ex
 
-curl -sSL http://mirror.centos.org/altarch/7/isos/aarch64/CentOS-7-aarch64-rootfs-7.4.1708.tar.xz | xz -d | pv | sudo tar --numeric-owner -xpf - -C rootfs/
+curl -sSL http://mirror.centos.org/altarch/7.4.1708/isos/aarch64/CentOS-7-aarch64-rootfs-7.4.1708.tar.xz | xz -d | pv | sudo tar --numeric-owner -xpf - -C rootfs/
 
 sudo cp centos-02.sh ./rootfs
 sudo cp centos-03.sh ./rootfs


### PR DESCRIPTION
The CentOS-7-aarch64-rootfs-7.4.1708.tar.xz file only exists in version 7.4.1708